### PR TITLE
enable cve-bin-tool on Windows for ntopdocs dir

### DIFF
--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -149,6 +149,7 @@ class VersionScanner:
             # Ignore special files that are known non-executable
             if Path(filename).suffix == '.ntop':
                 return False, None
+
             # use system file if available (for performance reasons)
             try:
                 output = subprocess.check_output(["file", filename]).decode(

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -146,7 +146,7 @@ class VersionScanner:
 
         output: str | None = None
         if inpath("file"):
-            # Ignore special files that are known non-binary
+            # Ignore special files that are known non-executable
             if Path(filename).suffix == '.ntop':
                 return False, None
             # use system file if available (for performance reasons)

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -146,6 +146,9 @@ class VersionScanner:
 
         output: str | None = None
         if inpath("file"):
+            # Ignore special files that are known non-binary
+            if Path(filename).suffix == '.ntop':
+                return False, None
             # use system file if available (for performance reasons)
             try:
                 output = subprocess.check_output(["file", filename]).decode(


### PR DESCRIPTION
### Summary
Slight modification to cve-bin-tool is made such that `.ntop` files are not checked. Some .ntop files cause cve-bin-tool to hang indefinitely due to an issue with regex in the version check that occurs when a file is scanned.